### PR TITLE
render nothing をheadで置き換えました

### DIFF
--- a/app/controllers/healthcheck_rails/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_rails/healthcheck_controller.rb
@@ -1,7 +1,7 @@
 module HealthcheckRails
   class HealthcheckController < ApplicationController
     def index
-      render nothing: true, status: :ok
+      head :ok
     end
   end
 end


### PR DESCRIPTION
## 変更理由
- rails 5.1 で `nothing` オプションが使えなくなったので `head` に変更しました

ref: https://stackoverflow.com/questions/34688726/the-nothing-option-is-deprecated-and-will-be-removed-in-rails-5-1